### PR TITLE
Remove support for obsolete directive "Disclosure"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ const securityTxt = require('express-security-txt')
 
 const options = {
   contact: 'email@example.com',
-  disclosure: 'full',
   encryption: 'https://www.mykey.com/pgp-key.txt',
   acknowledgement: 'thank you'
 }

--- a/__tests__/formatPolicy.test.js
+++ b/__tests__/formatPolicy.test.js
@@ -3,7 +3,6 @@ const securityTxt = require('../index')
 test('formats successfully with correct fields (singular contact field)', () => {
   const options = {
     contact: 'email@example.com',
-    disclosure: 'full',
     encryption: 'https://www.mykey.com/pgp-key.txt',
     acknowledgement: 'thank you'
   }
@@ -12,23 +11,20 @@ test('formats successfully with correct fields (singular contact field)', () => 
 
   expect(res).toBe(
     'Contact: email@example.com\n' +
-    'Disclosure: full\n' +
     'Encryption: https://www.mykey.com/pgp-key.txt\n' +
     'Acknowledgement: thank you'
   )
 })
 
-test('formats successfully with mandatory fields only', () => {
+test('formats successfully with mandatory field only', () => {
   const options = {
     contact: 'email@example.com',
-    disclosure: 'full'
   }
 
   const res = securityTxt.formatSecurityPolicy(options)
 
   expect(res).toBe(
-    'Contact: email@example.com\n' +
-    'Disclosure: full'
+    'Contact: email@example.com
   )
 })
 
@@ -36,7 +32,6 @@ test('formats successfully with multiple contact options and values in-tact', ()
   const email = 'email@example.com'
   const website = 'http://www.website.com'
   const phone = '+972+8+6173651'
-  const disclosure = 'partial'
   const encryption = 'https://www.mykey.com/pgp-key.txt'
   const acknowledgement = 'http://my.website.com'
 
@@ -46,7 +41,6 @@ test('formats successfully with multiple contact options and values in-tact', ()
       website,
       phone
     ],
-    disclosure: disclosure,
     encryption: encryption,
     acknowledgement: acknowledgement
   }
@@ -57,7 +51,6 @@ test('formats successfully with multiple contact options and values in-tact', ()
     `Contact: ${email}\n` +
     `Contact: ${website}\n` +
     `Contact: ${phone}\n` +
-    `Disclosure: ${disclosure}\n` +
     `Encryption: ${encryption}\n` +
     `Acknowledgement: ${acknowledgement}`
   )
@@ -66,7 +59,6 @@ test('formats successfully with multiple contact options and values in-tact', ()
 test('formats successfully with policy, hiring and signature fields', () => {
   const options = {
     contact: 'email@example.com',
-    disclosure: 'full',
     signature: 'http://example.com/.well-known/signature.txt.sig',
     policy: 'http://example.com/policy.txt',
     hiring: 'http://example.com/hiring.txt'
@@ -76,7 +68,6 @@ test('formats successfully with policy, hiring and signature fields', () => {
 
   expect(res).toBe(
     'Contact: email@example.com\n' +
-    'Disclosure: full\n' +
     'Signature: http://example.com/.well-known/signature.txt.sig\n' +
     'Policy: http://example.com/policy.txt\n' +
     'Hiring: http://example.com/hiring.txt'

--- a/__tests__/formatPolicy.test.js
+++ b/__tests__/formatPolicy.test.js
@@ -18,7 +18,7 @@ test('formats successfully with correct fields (singular contact field)', () => 
 
 test('formats successfully with mandatory field only', () => {
   const options = {
-    contact: 'email@example.com',
+    contact: 'email@example.com'
   }
 
   const res = securityTxt.formatSecurityPolicy(options)

--- a/__tests__/formatPolicy.test.js
+++ b/__tests__/formatPolicy.test.js
@@ -24,7 +24,7 @@ test('formats successfully with mandatory field only', () => {
   const res = securityTxt.formatSecurityPolicy(options)
 
   expect(res).toBe(
-    'Contact: email@example.com
+    'Contact: email@example.com'
   )
 })
 

--- a/__tests__/middleware.test.js
+++ b/__tests__/middleware.test.js
@@ -3,7 +3,6 @@ const securityTxtMiddleware = require('../index')
 test('correctly handle middleware setup for security policy', () => {
   const options = {
     contact: 'email@example.com',
-    disclosure: 'full',
     encryption: 'https://www.mykey.com/pgp-key.txt',
     acknowledgement: 'thank you'
   }
@@ -33,7 +32,6 @@ test('correctly handle middleware setup for security policy', () => {
 test('skip middleware if method is not GET', () => {
   const options = {
     contact: 'email@example.com',
-    disclosure: 'full',
     encryption: 'https://www.mykey.com/pgp-key.txt',
     acknowledgement: 'thank you'
   }
@@ -55,7 +53,6 @@ test('skip middleware if method is not GET', () => {
 test('skip middleware if path is not /security.txt', () => {
   const options = {
     contact: 'email@example.com',
-    disclosure: 'full',
     encryption: 'https://www.mykey.com/pgp-key.txt',
     acknowledgement: 'thank you'
   }

--- a/__tests__/validatePolicy.test.js
+++ b/__tests__/validatePolicy.test.js
@@ -3,7 +3,6 @@ const securityTxt = require('../index')
 test('validate doesnt throw an error on provided fields', () => {
   const options = {
     contact: 'email@example.com',
-    disclosure: 'full',
     encryption: 'https://www.mykey.com/pgp-key.txt',
     acknowledgement: 'thank you'
   }
@@ -14,20 +13,10 @@ test('validate doesnt throw an error on provided fields', () => {
 
 test('validate successfully when only mandatory properties provided', () => {
   const options = {
-    contact: 'email@example.com',
-    disclosure: 'full'
+    contact: 'email@example.com'
   }
 
   expect(() => securityTxt.validatePolicyFields(options)).not.toThrow()
-})
-
-test('validate fails when disclosure is non-standard', () => {
-  const options = {
-    contact: 'email@example.com',
-    disclosure: 'abc'
-  }
-
-  expect(() => securityTxt.validatePolicyFields(options)).toThrow()
 })
 
 test('validate fails when options is not an object', () => {
@@ -38,16 +27,6 @@ test('validate fails when options is not an object', () => {
 
 test('validate fails when no contact property provided', () => {
   const options = {
-    disclosure: 'full',
-    encryption: 'https://www.mykey.com/pgp-key.txt'
-  }
-
-  expect(() => securityTxt.validatePolicyFields(options)).toThrow()
-})
-
-test('validate fails when no disclosure property provided', () => {
-  const options = {
-    contact: 'email@example.com',
     encryption: 'https://www.mykey.com/pgp-key.txt'
   }
 
@@ -57,7 +36,6 @@ test('validate fails when no disclosure property provided', () => {
 test('validate fails when encryption property is used without https', () => {
   const options = {
     contact: 'email@example.com',
-    disclosure: 'full',
     encryption: 'http://www.mykey.com/pgp-key.txt'
   }
 
@@ -67,7 +45,6 @@ test('validate fails when encryption property is used without https', () => {
 test('validate fails when encryption property is not a string', () => {
   const options = {
     contact: 'email@example.com',
-    disclosure: 'full',
     encryption: {}
   }
 
@@ -77,7 +54,6 @@ test('validate fails when encryption property is not a string', () => {
 test('validate fails when acknowledgement property is not a string', () => {
   const options = {
     contact: 'email@example.com',
-    disclosure: 'full',
     encryption: '',
     acknowledgement: {}
   }
@@ -88,7 +64,6 @@ test('validate fails when acknowledgement property is not a string', () => {
 test('validate fails when policy property is not a string', () => {
   const options = {
     contact: 'email@example.com',
-    disclosure: 'full',
     policy: {}
   }
 
@@ -98,7 +73,6 @@ test('validate fails when policy property is not a string', () => {
 test('validate fails when signature property is not a string', () => {
   const options = {
     contact: 'email@example.com',
-    disclosure: 'full',
     signature: {}
   }
 
@@ -108,7 +82,6 @@ test('validate fails when signature property is not a string', () => {
 test('validate fails when hiring property is not a string', () => {
   const options = {
     contact: 'email@example.com',
-    disclosure: 'full',
     hiring: {}
   }
 

--- a/index.js
+++ b/index.js
@@ -40,8 +40,6 @@ class middleware {
       policySetting['Contact'] = options.contact
     }
 
-    policySetting['Disclosure'] = options.disclosure
-
     if (options.encryption) {
       policySetting['Encryption'] = options.encryption
     }
@@ -90,15 +88,6 @@ class middleware {
 
     if (!options.contact) {
       throw new Error('express-security-txt: need to specify a contact property in options')
-    }
-
-    if (!options.disclosure || typeof options.disclosure !== 'string') {
-      throw new Error('express-security-txt: need to specify a disclosure property in options')
-    }
-
-    const disclosureOption = options.disclosure.toLowerCase()
-    if (disclosureOption !== 'full' && disclosureOption !== 'partial' && disclosureOption !== 'none') {
-      throw new Error('express-security-txt: invalid disclosure option')
     }
 
     if (options.encryption) {


### PR DESCRIPTION
The latest internet draft does not contain any information about the "Disclosure" field. Hence,
documentation, tests, and code are changed to remove support for that directive.

BREAKING CHANGE: Passing a "disclosure" property no longer leads to a "Disclosure" directive in the
security.txt file

#15

I did not manage to get the tests to work. I couldn't get them to work _before_ I made my changes, too, so I'm not sure what's going on.