### PR TITLE
feat(index.js, __tests__): Support the Permission: directive

### DIFF
--- a/__tests__/formatPolicy.test.js
+++ b/__tests__/formatPolicy.test.js
@@ -75,3 +75,17 @@ test('formats successfully with policy, hiring and signature fields', () => {
     'Hiring: http://example.com/hiring.txt'
   )
 })
+
+test('formats successfully with "none" not in lowercase for Permission: directive', () => {
+  const options = {
+    contact: 'email@example.com',
+    permission: 'NoNe'
+  }
+
+  const res = securityTxt.formatSecurityPolicy(options)
+
+  expect(res).toBe(
+    'Contact: email@example.com\n' +
+    'Permission: NoNe'
+  )
+})

--- a/__tests__/formatPolicy.test.js
+++ b/__tests__/formatPolicy.test.js
@@ -4,7 +4,8 @@ test('formats successfully with correct fields (singular contact field)', () => 
   const options = {
     contact: 'email@example.com',
     encryption: 'https://www.mykey.com/pgp-key.txt',
-    acknowledgement: 'thank you'
+    acknowledgement: 'thank you',
+    permission: 'none'
   }
 
   const res = securityTxt.formatSecurityPolicy(options)
@@ -12,7 +13,8 @@ test('formats successfully with correct fields (singular contact field)', () => 
   expect(res).toBe(
     'Contact: email@example.com\n' +
     'Encryption: https://www.mykey.com/pgp-key.txt\n' +
-    'Acknowledgement: thank you'
+    'Acknowledgement: thank you\n' +
+    'Permission: none'
   )
 })
 

--- a/__tests__/validatePolicy.test.js
+++ b/__tests__/validatePolicy.test.js
@@ -87,3 +87,21 @@ test('validate fails when hiring property is not a string', () => {
 
   expect(() => securityTxt.validatePolicyFields(options)).toThrow()
 })
+
+test('validate fails when permission property is not a string', () => {
+  const options = {
+    contact: 'email@example.com',
+    permission: {}
+  }
+
+  expect(() => securityTxt.validatePolicyFields(options)).toThrow()
+})
+
+test('validate fails when permission property is not "none"', () => {
+  const options = {
+    contact: 'email@example.com',
+    permission: 'notnone'
+  }
+
+  expect(() => securityTxt.validatePolicyFields(options)).toThrow()
+})

--- a/index.js
+++ b/index.js
@@ -60,6 +60,10 @@ class middleware {
       policySetting['Hiring'] = options.hiring
     }
 
+    if (options.permission) {
+      policySetting['Permission'] = options.permission
+    }
+
     const tmpPolicyArray = []
     for (const [field, value] of Object.entries(policySetting)) {
       if (typeof value === 'object') {
@@ -114,6 +118,10 @@ class middleware {
 
     if (options.hiring && typeof options.hiring !== 'string') {
       throw new Error('express-security-txt: invalid hiring property, expecting string in options')
+    }
+
+    if (options.permission && options.permission !== 'none') {
+      throw new Error('express-security-txt: invalid permission property, expecting string value "none" in options')
     }
 
     return true

--- a/index.js
+++ b/index.js
@@ -120,8 +120,14 @@ class middleware {
       throw new Error('express-security-txt: invalid hiring property, expecting string in options')
     }
 
-    if (options.permission && options.permission !== 'none') {
-      throw new Error('express-security-txt: invalid permission property, expecting string value "none" in options')
+    if (options.permission) {
+      if (typeof options.permission !== 'string') {
+        throw new Error('express-security-txt: invalid permission property, expecting string in options')
+      }
+      
+      if (options.permission.toLowerCase() !== 'none') {
+        throw new Error('express-security-txt: invalid permission property, must be string value "none"')
+      }
     }
 
     return true

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ class middleware {
       if (typeof options.permission !== 'string') {
         throw new Error('express-security-txt: invalid permission property, expecting string in options')
       }
-      
+
       if (options.permission.toLowerCase() !== 'none') {
         throw new Error('express-security-txt: invalid permission property, must be string value "none"')
       }


### PR DESCRIPTION
The `Permission:` directive tells security researchers to avoid looking for security vulnerabilities. It must be provided no more than once, with a string value of `'none'`. This is tested for.

Some questions:
1. Is it a `feat` rather than a `fix`?

2. The validation code for the _Permission:_ directive is not split into a test for string-ness and a test for equality to `"none"`. Instead, both these tests are done in one go. This means a generic error message of `Expecting the string "none"` is shown, rather than `Expecting a string` or `Expecting "none"`. Given that only one value is allowed, is showing only one error acceptable?  (This is different to how the validation for _Encryption:_ is structured)

Also a note: the spec doesn't appear to clearly state whether `none` has to be in lowercase letters, but I assume that since URLs can be case-sensitive, all values must be.

Tested manually (and automatic tests added).

Also, I tried running `yarn run test:coverage` and it didn't work :( `error Command "test:coverage" not found.`

Thanks so much for all the support and help btw!