### PR TITLE
docs(README): coverage is built into the test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,6 @@ Project linting:
 yarn run lint
 ```
 
-## Coverage
-
-```bash
-yarn run test:coverage
-```
-
 ## Contributing
 
 ### Commit Guidelines


### PR DESCRIPTION
Removes the irrelevant `yarn run test:coverge` command due to coverage being reported by default during tests using `yarn run test`