### PR TITLE
fix(#validatePolicyFields): Allow non-web schemes for Encryption: directive

### DIFF
--- a/__tests__/validatePolicy.test.js
+++ b/__tests__/validatePolicy.test.js
@@ -33,13 +33,22 @@ test('validate fails when no contact property provided', () => {
   expect(() => securityTxt.validatePolicyFields(options)).toThrow()
 })
 
-test('validate fails when encryption property is used without https', () => {
+test('validate fails when encryption property is used with insecure http', () => {
   const options = {
     contact: 'email@example.com',
     encryption: 'http://www.mykey.com/pgp-key.txt'
   }
 
   expect(() => securityTxt.validatePolicyFields(options)).toThrow()
+})
+
+test('validate successfully when encryption property is used with dns scheme', () => {
+  const options = {
+    contact: 'email@example.com',
+    encryption: 'dns:abc'
+  }
+
+  expect(() => securityTxt.validatePolicyFields(options)).not.toThrow()
 })
 
 test('validate fails when encryption property is not a string', () => {

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ class middleware {
         throw new Error('express-security-txt: invalid encyprtion property, expecting string')
       }
 
-      if (options.encryption.toLowerCase().substr(0, 8) !== 'https://') {
+      if (options.encryption.toLowerCase().substr(0, 7) === 'http://') {
         throw new Error('express-security-txt: invalid encyprtion property, must be provided as HTTPS uri')
       }
     }


### PR DESCRIPTION
Resolves #24

Would it be better to make this change _not_ comply with semantic versioning, since that way there's no chance of a second release with no changes?

Changes: instead of only allowing HTTPS, disallow HTTP -- and test.