### PR TITLE
Add a security policy to receive vulnerability reports

### DIFF
--- a/.security.txt
+++ b/.security.txt
@@ -1,0 +1,5 @@
+Contact: https://hackerone.com/nodejs-ecosystem
+# Please specify the module name (express-security-txt) when emailing
+Contact: mailto:security-ecosystem@nodejs.org
+Policy: https://github.com/lirantal/express-security-txt/blob/master/SECURITY.md
+Policy: https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+This project participates in the Responsible Disclosure Policy program for the Node.js Security Ecosystem.
+
+# Responsible Disclosure Policy
+
+A responsible disclosure policy helps protect the project and its users from security vulnerabilities discovered in the project’s scope by employing a process where vulnerabilities are publicly disclosed after a reasonable time period to allow patching the vulnerability. 
+
+All security bugs are taken seriously and are considered as top priority. 
+Your efforts to responsibly disclose your findings are appreciated and will be taken into account to acknowledge your contributions.
+
+
+## Reporting a Security Issue
+
+Any security related issue should be reported to the [Node.js Ecosystem](https://hackerone.com/nodejs-ecosystem
+) program hosted on HackerOne which follows the [3rd party responsible disclosure process](https://github.com/nodejs/security-wg/blob/master/processes/third_party_vuln_process.md) set by the Node.js Security WG. One may also directly contact the project’s maintainers, but through the HackerOne program the Security WG members will take care of triaging the vulnerability and invite project maintainers to participate in the report.
+
+As an alternative method, vulnerabilities can also be reported by emailing security-ecosystem@nodejs.org.


### PR DESCRIPTION
`.security.txt` is added, intended for automated parsing tools; and `SECURITY.md` is added for human
consumption and as a policy.

Should the license asserting the Node.js Foundation's copyright be included?

Resolves #28