### PR TITLE
Append a newline terminator on the last line of the generated file

### DIFF
--- a/__tests__/formatPolicy.test.js
+++ b/__tests__/formatPolicy.test.js
@@ -14,7 +14,7 @@ test('formats successfully with correct fields (singular contact field)', () => 
     'Contact: email@example.com\n' +
     'Encryption: https://www.mykey.com/pgp-key.txt\n' +
     'Acknowledgement: thank you\n' +
-    'Permission: none'
+    'Permission: none\n'
   )
 })
 
@@ -26,7 +26,7 @@ test('formats successfully with mandatory field only', () => {
   const res = securityTxt.formatSecurityPolicy(options)
 
   expect(res).toBe(
-    'Contact: email@example.com'
+    'Contact: email@example.com\n'
   )
 })
 
@@ -54,7 +54,7 @@ test('formats successfully with multiple contact options and values in-tact', ()
     `Contact: ${website}\n` +
     `Contact: ${phone}\n` +
     `Encryption: ${encryption}\n` +
-    `Acknowledgement: ${acknowledgement}`
+    `Acknowledgement: ${acknowledgement}\n`
   )
 })
 
@@ -72,7 +72,7 @@ test('formats successfully with policy, hiring and signature fields', () => {
     'Contact: email@example.com\n' +
     'Signature: http://example.com/.well-known/signature.txt.sig\n' +
     'Policy: http://example.com/policy.txt\n' +
-    'Hiring: http://example.com/hiring.txt'
+    'Hiring: http://example.com/hiring.txt\n'
   )
 })
 
@@ -86,6 +86,6 @@ test('formats successfully with "none" not in lowercase for Permission: directiv
 
   expect(res).toBe(
     'Contact: email@example.com\n' +
-    'Permission: NoNe'
+    'Permission: NoNe\n'
   )
 })

--- a/index.js
+++ b/index.js
@@ -63,14 +63,14 @@ class middleware {
     }
 
     const tmpPolicyArray = []
-    for (const [field, value] of Object.entries(policySetting)) {
-      if (typeof value === 'object') {
-        value.forEach(valueOption => {
-          tmpPolicyArray.push(`${field}: ${valueOption}`)
-        })
-      } else {
-        tmpPolicyArray.push(`${field}: ${value}`)
+    for (let [field, value] of Object.entries(policySetting)) {
+      if (typeof value !== 'object') {
+        value = [ value ]
       }
+
+      value.forEach(valueOption => {
+        tmpPolicyArray.push(`${field}: ${valueOption}`)
+      })
     }
 
     policySettingText = tmpPolicyArray.join('\n')

--- a/index.js
+++ b/index.js
@@ -69,11 +69,11 @@ class middleware {
       }
 
       value.forEach(valueOption => {
-        tmpPolicyArray.push(`${field}: ${valueOption}`)
+        tmpPolicyArray.push(`${field}: ${valueOption}\n`)
       })
     }
 
-    policySettingText = tmpPolicyArray.join('\n')
+    policySettingText = tmpPolicyArray.join('')
     return policySettingText
   }
 


### PR DESCRIPTION
Resolves #36 

In this pull request, we first make a very slight refactor, converting something like

```
{
  "contact": "tel:+123"
}
```

to be internally represented more like

```
{
  "contact": ["tel:+123"]
}
```

This makes the next commit a bit cleaner. In making this change, we change a `const` to a `let`.

<hr>

Next, we insert a newline character on every line, and then we join by the empty string rather than a newline. (This has one effect: it places a newline character on the last line too)

However, this breaks tests, so we modify the tests too.

<hr>

We make these changes because they are mandated by the specification, and also because UNIX tools (like `cat`) work better with a newline terminator.