### PR TITLE
Implement comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ const options = {
 
 app.use(securityTxt.setup(options))
 ```
-
 ### Chaining
 
 Where allowed, you can provide multiple values for a single directive by passing an array.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and use it as a middleware for an express app.
 const securityTxt = require('express-security-txt')
 
 const options = {
-  contact: 'email@example.com',
+  contact: 'mailto:email@example.com',
   encryption: 'https://www.mykey.com/pgp-key.txt',
   acknowledgement: 'thank you'
 }
@@ -42,6 +42,81 @@ const options = {
 app.use(securityTxt.setup(options))
 ```
 
+### Chaining
+
+Where allowed, you can provide multiple values for a single directive by passing an array.
+
+```js
+const securityTxt = require('express-security-txt')
+
+const options = {
+  contact: [
+    'https://firstMethodOfContact.example.com',
+    'https://secondMethodOfContact.example.com'
+  ]
+}
+
+app.use(securityTxt.setup(options))
+```
+
+### Comments
+
+To add a comment at the beggining or end of the security.txt file, one may use the keys `_prefixComment` and `postfixComment` respectively. If one wishes to place a comment immediately before a field, one may use an object which specifies the value of the field and the comment which must introduce it.
+
+```js
+const securityTxt = require('express-security-txt')
+
+const options = {
+  _prefixComment: 'This comment goes at the very beggining of the file',
+  contact: {
+    comment: 'This comment goes directly before the Contact: directive',
+    value: 'mailto:email@example.com'
+  },
+  encryption: [
+    'https://example.com/encryption',
+    {
+      comment: 'Comments can appear in the middle of an array of values',
+      value: 'https://example.com/alternativeEncryption'
+    }
+  ],
+  _postfixComment: 'This comment goes at the very end of the file'
+}
+
+app.use(securityTxt.setup(options))
+```
+
+Would generate the file
+
+```txt
+# This comment goes at the very beggining of the file
+# This comment goes directly before the Contact: directive
+Contact: mailto:email@example.com
+Encryption: https://example.com/encryption
+# Comments can appear in the middle of an array of values
+Encryption: https://example.com/alternativeEncryption
+# This comment goes at the very end of the file
+```
+
+If your comment spans multiple lines, you can use `\n` to split it. express-security-txt will automatically insert the relevant `#` symbols. Alternatively, one can use an array of lines instead of a string.
+
+For example:
+
+```js
+const options = {
+  _prefixComment: ['this is a', 'comment\nwhich', 'spans many lines'],
+  contact: 'mailto:email@example.com'
+}
+```
+
+Would generate
+
+```txt
+# this is a
+# comment
+# which
+# spans many lines
+Contact: mailto:email@example.com
+```
 ## Tests
 
 Project tests:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ app.use(securityTxt.setup(options))
 
 ### Comments
 
-To add a comment at the beggining or end of the security.txt file, one may use the keys `_prefixComment` and `postfixComment` respectively. If one wishes to place a comment immediately before a field, one may use an object which specifies the value of the field and the comment which must introduce it.
+To add a comment at the beggining or end of the security.txt file, one may use the keys `_prefixComment` and `_postfixComment` respectively. If one wishes to place a comment immediately before a field, one may use an object which specifies the value of the field and the comment which must come before it.
 
 ```js
 const securityTxt = require('express-security-txt')

--- a/__tests__/formatPolicy.test.js
+++ b/__tests__/formatPolicy.test.js
@@ -89,3 +89,37 @@ test('formats successfully with "none" not in lowercase for Permission: directiv
     'Permission: NoNe\n'
   )
 })
+
+test('formats successfully with comments', () => {
+  const options = {
+    contact: {
+      comment: 'b',
+      value: 'tel:+123'
+    },
+    encryption: [
+      {
+        value: 'https://a.example.com'
+      },
+      {
+        value: 'https://b.example.com',
+        comment: 'c'
+      },
+      'https://c.example.com'
+    ],
+    _prefixComment: 'a',
+    _postfixComment: 'd'
+  }
+
+  const res = securityTxt.formatSecurityPolicy(options)
+
+  expect(res).toBe(
+    '# a\n' +
+    '# b\n' +
+    'Contact: tel:+123\n' +
+    'Encryption: https://a.example.com\n' +
+    '# c\n' +
+    'Encryption: https://b.example.com\n' +
+    'Encryption: https://c.example.com\n' +
+    '# d\n'
+  )
+})

--- a/__tests__/formatPolicy.test.js
+++ b/__tests__/formatPolicy.test.js
@@ -102,11 +102,11 @@ test('formats successfully with comments', () => {
       },
       {
         value: 'https://b.example.com',
-        comment: 'c'
+        comment: ['c', 'h', 'i\nj']
       },
       'https://c.example.com'
     ],
-    _prefixComment: 'a',
+    _prefixComment: ['a', 'z', 'x\ny'],
     _postfixComment: 'd'
   }
 
@@ -114,10 +114,16 @@ test('formats successfully with comments', () => {
 
   expect(res).toBe(
     '# a\n' +
+    '# z\n' +
+    '# x\n' +
+    '# y\n' +
     '# b\n' +
     'Contact: tel:+123\n' +
     'Encryption: https://a.example.com\n' +
     '# c\n' +
+    '# h\n' +
+    '# i\n' +
+    '# j\n' +
     'Encryption: https://b.example.com\n' +
     'Encryption: https://c.example.com\n' +
     '# d\n'

--- a/__tests__/validatePolicy.test.js
+++ b/__tests__/validatePolicy.test.js
@@ -136,3 +136,56 @@ test('validate fails when providing arrays for signature/permission', () => {
 
   expect(() => securityTxt.validatePolicyFields(options)).toThrow()
 })
+
+test('validate successfully when using prefix/postfix comments', () => {
+  const options = {
+    _prefixComment: 'This is a prefix comment',
+    _postfixComment: 'This is a postfix comment',
+    contact: 'mailto:security@example.com'
+  }
+
+  expect(() => securityTxt.validatePolicyFields(options)).not.toThrow()
+})
+
+test('validate successfully when using objects for comments', () => {
+  const options = {
+    contact: [
+      {
+        comment: '...',
+        value: 'mailto:security@example.com'
+      },
+      {
+        value: 'tel:+123'
+      }
+    ],
+    encryption: {
+      comment: '...',
+      value: 'https://encryption.example.com'
+    }
+  }
+
+  expect(() => securityTxt.validatePolicyFields(options)).not.toThrow()
+})
+
+test('validate fails when not providing a value in comment object', () => {
+  const singleObject = {
+    contact: {
+      comment: ''
+    }
+  }
+
+  const arrayOfObjects = {
+    contact: [
+      {
+        comment: '...',
+        value: 'tel:+123'
+      },
+      {
+        comment: '...'
+      }
+    ]
+  }
+
+  expect(() => securityTxt.validatePolicyFields(singleObject)).toThrow()
+  expect(() => securityTxt.validatePolicyFields(arrayOfObjects)).toThrow()
+})

--- a/__tests__/validatePolicy.test.js
+++ b/__tests__/validatePolicy.test.js
@@ -139,8 +139,8 @@ test('validate fails when providing arrays for signature/permission', () => {
 
 test('validate successfully when using prefix/postfix comments', () => {
   const options = {
-    _prefixComment: 'This is a prefix comment',
-    _postfixComment: 'This is a postfix comment',
+    _prefixComment: ['This is a\nprefix', 'comment'],
+    _postfixComment: 'This is a \npostfix comment',
     contact: 'mailto:security@example.com'
   }
 
@@ -151,7 +151,7 @@ test('validate successfully when using objects for comments', () => {
   const options = {
     contact: [
       {
-        comment: '...',
+        comment: ['...', '...'],
         value: 'mailto:security@example.com'
       },
       {

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ class middleware {
     for (let directive of DIRECTIVES) {
       const key = this.camelCase(directive)
 
-      if(!options.hasOwnProperty(key)) {
+      if (!options.hasOwnProperty(key)) {
         continue
       }
 
@@ -98,10 +98,8 @@ class middleware {
    * @param {string} directive - The name of the security.txt directive
    * @return {strng} The camelCase version of the directive
    */
-  static camelCase(directive) {   
-    return directive.split('-')
-                    .map((word, isNotFirst) => isNotFirst ? word : word.toLowerCase())
-                    .join('')
+  static camelCase (directive) {
+    return directive.split('-').map((word, isNotFirst) => isNotFirst ? word : word.toLowerCase()).join('')
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
+const DIRECTIVES = ['Contact', 'Encryption', 'Acknowledgement', 'Signature', 'Policy', 'Hiring', 'Permission']
 
 class middleware {
   /**
@@ -34,42 +35,23 @@ class middleware {
     this.validatePolicyFields(options)
 
     let policySettingText = ''
-    const policySetting = []
-
-    policySetting['Contact'] = options.contact
-
-    if (options.encryption) {
-      policySetting['Encryption'] = options.encryption
-    }
-
-    if (options.acknowledgement) {
-      policySetting['Acknowledgement'] = options.acknowledgement
-    }
-
-    if (options.signature) {
-      policySetting['Signature'] = options.signature
-    }
-
-    if (options.policy) {
-      policySetting['Policy'] = options.policy
-    }
-
-    if (options.hiring) {
-      policySetting['Hiring'] = options.hiring
-    }
-
-    if (options.permission) {
-      policySetting['Permission'] = options.permission
-    }
 
     const tmpPolicyArray = []
-    for (let [field, value] of Object.entries(policySetting)) {
+    for (let directive of DIRECTIVES) {
+      const key = this.camelCase(directive)
+
+      if(!options.hasOwnProperty(key)) {
+        continue
+      }
+
+      let value = options[key]
+
       if (typeof value !== 'object') {
         value = [ value ]
       }
 
       value.forEach(valueOption => {
-        tmpPolicyArray.push(`${field}: ${valueOption}\n`)
+        tmpPolicyArray.push(`${directive}: ${valueOption}\n`)
       })
     }
 
@@ -104,6 +86,22 @@ class middleware {
     }
 
     return true
+  }
+
+  /**
+   * Converts a security.txt directive like 'Contact'
+   * to the camelCase field name like 'contact'
+   *
+   * We assume that the contains a sequence of capitalised
+   * words which have been strung together with hyphens.
+   *
+   * @param {string} directive - The name of the security.txt directive
+   * @return {strng} The camelCase version of the directive
+   */
+  static camelCase(directive) {   
+    return directive.split('-')
+                    .map((word, isNotFirst) => isNotFirst ? word : word.toLowerCase())
+                    .join('')
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -118,15 +118,15 @@ class middleware {
      * @param {object} [singleValue=Joi.string()] - a Joi schema to validate a single entry (e.g. of an array)
      * @param {boolean} [required=false] - whether this schema must be present
      */
-    const fieldValue = ({canBeArray = true, singleValue = string, required = false} = {}) => {
+    const fieldValue = ({ canBeArray = true, singleValue = string, required = false } = {}) => {
       let schema = Joi.alternatives()
-      
+
       schema = schema.try(singleValue)
       schema = schema.try(Joi.object().keys({
         comment: string,
         value: (canBeArray ? array.items(schema) : schema).required()
       }))
-      
+
       if (canBeArray) {
         schema = schema.try(array.items(schema))
       }
@@ -140,13 +140,13 @@ class middleware {
 
     const schema = Joi.object().keys({
       _prefixComment: string,
-      acknowledgement: fieldValue(), 
-      contact: fieldValue({required: true}),
-      permission: fieldValue({canBeArray: false, singleValue: string.only('none').insensitive()}),
-      encryption: fieldValue({singleValue: string.regex(/^(?!http:)/i)}),
+      acknowledgement: fieldValue(),
+      contact: fieldValue({ required: true }),
+      permission: fieldValue({ canBeArray: false, singleValue: string.only('none').insensitive() }),
+      encryption: fieldValue({ singleValue: string.regex(/^(?!http:)/i) }),
       policy: fieldValue(),
-      hiring: fieldValue(), 
-      signature: fieldValue({canBeArray: false}),
+      hiring: fieldValue(),
+      signature: fieldValue({ canBeArray: false }),
       _postfixComment: string
     }).label('options').required()
 

--- a/index.js
+++ b/index.js
@@ -60,12 +60,20 @@ class middleware {
 
       let value = options[key] // eslint-disable-line security/detect-object-injection
 
-      if (typeof value !== 'object') {
+      if (!Array.isArray(value)) {
         value = [ value ]
       }
 
       value.forEach(valueOption => {
-        tmpPolicyArray.push(`${directive}: ${valueOption}\n`)
+        if (valueOption.hasOwnProperty('value')) {
+          if(valueOption.hasOwnProperty('comment')) {
+            tmpPolicyArray.push(asComment(valueOption.comment))
+          }
+
+          tmpPolicyArray.push(`${directive}: ${valueOption.value}\n`)
+        } else {
+          tmpPolicyArray.push(`${directive}: ${valueOption}\n`)
+        }
       })
     }
 

--- a/index.js
+++ b/index.js
@@ -33,6 +33,20 @@ class middleware {
     // Before applying formatting let's validate the options
     this.validatePolicyFields(options)
 
+    const asComment = comment => {
+      const flatten = (a, b) => a.concat(b)
+
+      if(!Array.isArray(comment)) {
+        comment = [ comment ]
+      }
+
+      return comment
+                    .map(n => n.split`\n`)
+                    .reduce(flatten, [])
+                    .map(n => `# ${n}\n`)
+                    .join``
+    }
+
     let policySettingText = ''
     const policySetting = []
 
@@ -73,6 +87,14 @@ class middleware {
       })
     }
 
+    if(typeof options._prefixComment !== 'undefined') {
+      tmpPolicyArray.unshift(asComment(options._prefixComment))
+    }
+
+    if(typeof options._postfixComment !== 'undefined') {
+      tmpPolicyArray.push(asComment(options._postfixComment))
+    }
+
     policySettingText = tmpPolicyArray.join('')
     return policySettingText
   }
@@ -88,13 +110,15 @@ class middleware {
     const string = Joi.string()
 
     const schema = Joi.object().keys({
+      _prefixComment: string,
       acknowledgement: array.items(string),
       contact: array.required().items(string.required()),
       permission: string.only('none').insensitive(),
       encryption: array.items(string.regex(/^(?!http:)/i)),
       policy: array.items(string),
       hiring: array.items(string),
-      signature: string
+      signature: string,
+      _postfixComment: string
     }).label('options').required()
 
     const result = Joi.validate(options, schema)

--- a/index.js
+++ b/index.js
@@ -66,14 +66,14 @@ class middleware {
 
       value.forEach(valueOption => {
         if (valueOption.hasOwnProperty('value')) {
-          if(valueOption.hasOwnProperty('comment')) {
+          if (valueOption.hasOwnProperty('comment')) {
             tmpPolicyArray.push(asComment(valueOption.comment))
           }
 
-          tmpPolicyArray.push(`${directive}: ${valueOption.value}\n`)
-        } else {
-          tmpPolicyArray.push(`${directive}: ${valueOption}\n`)
+          valueOption = valueOption.value
         }
+
+        tmpPolicyArray.push(`${directive}: ${valueOption}\n`)
       })
     }
 

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ class middleware {
 
       schema = schema.try(singleValue)
       schema = schema.try(Joi.object().keys({
-        comment: string,
+        comment: array.items(string),
         value: (canBeArray ? array.items(schema) : schema).required()
       }))
 
@@ -129,7 +129,7 @@ class middleware {
     }
 
     const schema = Joi.object().keys({
-      _prefixComment: string,
+      _prefixComment: array.items(string),
       acknowledgement: fieldValue(),
       contact: fieldValue({ required: true }),
       permission: fieldValue({ canBeArray: false, singleValue: string.only('none').insensitive() }),
@@ -137,7 +137,7 @@ class middleware {
       policy: fieldValue(),
       hiring: fieldValue(),
       signature: fieldValue({ canBeArray: false }),
-      _postfixComment: string
+      _postfixComment: array.items(string)
     }).label('options').required()
 
     const result = Joi.validate(options, schema)

--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ class middleware {
   static validatePolicyFields (options) {
     const array = Joi.array().single()
     const string = Joi.string()
+    const comment = array.items(string)
 
     /**
      * A function to create a custom schema for a security.txt
@@ -113,7 +114,7 @@ class middleware {
 
       schema = schema.try(singleValue)
       schema = schema.try(Joi.object().keys({
-        comment: array.items(string),
+        comment: comment,
         value: (canBeArray ? array.items(schema) : schema).required()
       }))
 
@@ -129,7 +130,7 @@ class middleware {
     }
 
     const schema = Joi.object().keys({
-      _prefixComment: array.items(string),
+      _prefixComment: comment,
       acknowledgement: fieldValue(),
       contact: fieldValue({ required: true }),
       permission: fieldValue({ canBeArray: false, singleValue: string.only('none').insensitive() }),
@@ -137,7 +138,7 @@ class middleware {
       policy: fieldValue(),
       hiring: fieldValue(),
       signature: fieldValue({ canBeArray: false }),
-      _postfixComment: array.items(string)
+      _postfixComment: comment
     }).label('options').required()
 
     const result = Joi.validate(options, schema)

--- a/index.js
+++ b/index.js
@@ -36,15 +36,15 @@ class middleware {
     const asComment = comment => {
       const flatten = (a, b) => a.concat(b)
 
-      if(!Array.isArray(comment)) {
+      if (!Array.isArray(comment)) {
         comment = [ comment ]
       }
 
       return comment
-                    .map(n => n.split`\n`)
-                    .reduce(flatten, [])
-                    .map(n => `# ${n}\n`)
-                    .join``
+        .map(n => n.split`\n`)
+        .reduce(flatten, [])
+        .map(n => `# ${n}\n`)
+        .join``
     }
 
     let policySettingText = ''
@@ -87,11 +87,11 @@ class middleware {
       })
     }
 
-    if(typeof options._prefixComment !== 'undefined') {
+    if (typeof options._prefixComment !== 'undefined') {
       tmpPolicyArray.unshift(asComment(options._prefixComment))
     }
 
-    if(typeof options._postfixComment !== 'undefined') {
+    if (typeof options._postfixComment !== 'undefined') {
       tmpPolicyArray.push(asComment(options._postfixComment))
     }
 
@@ -109,15 +109,44 @@ class middleware {
     const array = Joi.array().single()
     const string = Joi.string()
 
+    /**
+     * A function to create a custom schema for a security.txt
+     * field value.
+     *
+     * @param {object} [options={}] - requirements of this schema
+     * @param {boolean} [options.canBeArray=true] - can singleValue appear in an array
+     * @param {object} [singleValue=Joi.string()] - a Joi schema to validate a single entry (e.g. of an array)
+     * @param {boolean} [required=false] - whether this schema must be present
+     */
+    const fieldValue = ({canBeArray = true, singleValue = string, required = false} = {}) => {
+      let schema = Joi.alternatives()
+      
+      schema = schema.try(singleValue)
+      schema = schema.try(Joi.object().keys({
+        comment: string,
+        value: (canBeArray ? array.items(schema) : schema).required()
+      }))
+      
+      if (canBeArray) {
+        schema = schema.try(array.items(schema))
+      }
+
+      if (required) {
+        schema = schema.required()
+      }
+
+      return schema
+    }
+
     const schema = Joi.object().keys({
       _prefixComment: string,
-      acknowledgement: array.items(string),
-      contact: array.required().items(string.required()),
-      permission: string.only('none').insensitive(),
-      encryption: array.items(string.regex(/^(?!http:)/i)),
-      policy: array.items(string),
-      hiring: array.items(string),
-      signature: string,
+      acknowledgement: fieldValue(), 
+      contact: fieldValue({required: true}),
+      permission: fieldValue({canBeArray: false, singleValue: string.only('none').insensitive()}),
+      encryption: fieldValue({singleValue: string.regex(/^(?!http:)/i)}),
+      policy: fieldValue(),
+      hiring: fieldValue(), 
+      signature: fieldValue({canBeArray: false}),
       _postfixComment: string
     }).label('options').required()
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,6 @@ class middleware {
     // Before applying formatting let's validate the options
     this.validatePolicyFields(options)
 
-
     const asComment = comment => {
       const flatten = (a, b) => a.concat(b)
 

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ class middleware {
     for (let directive of DIRECTIVES) {
       const key = this.camelCase(directive)
 
-      if(!options.hasOwnProperty(key)) {
+      if (!options.hasOwnProperty(key)) {
         continue
       }
 
@@ -151,10 +151,8 @@ class middleware {
    * @param {string} directive - The name of the security.txt directive
    * @return {strng} The camelCase version of the directive
    */
-  static camelCase(directive) {   
-    return directive.split('-')
-                    .map((word, isNotFirst) => isNotFirst ? word : word.toLowerCase())
-                    .join('')
+  static camelCase (directive) {
+    return directive.split('-').map((word, isNotFirst) => isNotFirst ? word : word.toLowerCase()).join('')
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
+const DIRECTIVES = ['Contact', 'Encryption', 'Acknowledgement', 'Signature', 'Policy', 'Hiring', 'Permission']
 
 class middleware {
   /**
@@ -48,42 +49,23 @@ class middleware {
     }
 
     let policySettingText = ''
-    const policySetting = []
-
-    policySetting['Contact'] = options.contact
-
-    if (options.encryption) {
-      policySetting['Encryption'] = options.encryption
-    }
-
-    if (options.acknowledgement) {
-      policySetting['Acknowledgement'] = options.acknowledgement
-    }
-
-    if (options.signature) {
-      policySetting['Signature'] = options.signature
-    }
-
-    if (options.policy) {
-      policySetting['Policy'] = options.policy
-    }
-
-    if (options.hiring) {
-      policySetting['Hiring'] = options.hiring
-    }
-
-    if (options.permission) {
-      policySetting['Permission'] = options.permission
-    }
 
     const tmpPolicyArray = []
-    for (let [field, value] of Object.entries(policySetting)) {
+    for (let directive of DIRECTIVES) {
+      const key = this.camelCase(directive)
+
+      if(!options.hasOwnProperty(key)) {
+        continue
+      }
+
+      let value = options[key]
+
       if (typeof value !== 'object') {
         value = [ value ]
       }
 
       value.forEach(valueOption => {
-        tmpPolicyArray.push(`${field}: ${valueOption}\n`)
+        tmpPolicyArray.push(`${directive}: ${valueOption}\n`)
       })
     }
 
@@ -157,6 +139,22 @@ class middleware {
     }
 
     return true
+  }
+
+  /**
+   * Converts a security.txt directive like 'Contact'
+   * to the camelCase field name like 'contact'
+   *
+   * We assume that the contains a sequence of capitalised
+   * words which have been strung together with hyphens.
+   *
+   * @param {string} directive - The name of the security.txt directive
+   * @return {strng} The camelCase version of the directive
+   */
+  static camelCase(directive) {   
+    return directive.split('-')
+                    .map((word, isNotFirst) => isNotFirst ? word : word.toLowerCase())
+                    .join('')
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ class middleware {
         continue
       }
 
-      let value = options[key]
+      let value = options[key] // eslint-disable-line security/detect-object-injection
 
       if (typeof value !== 'object') {
         value = [ value ]

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ class middleware {
         continue
       }
 
-      let value = options[key]
+      let value = options[key] // eslint-disable-line security/detect-object-injection
 
       if (typeof value !== 'object') {
         value = [ value ]


### PR DESCRIPTION
***Moved to #43***


<hr>

**Important Note**: this pull request is built on top of #40. It should probably be merged in _after_ it therefore. About half of the commits in this PR are the commits from that PR. Sorry!

We provide a few ways to add comments. I deviated a little from my interpretations of the restrictions you suggested, because I think it should be possible to add a comment without changing anything other than the affected area. Let me know if this is okay

<hr>

```
{
  _prefixComment: "at the top of the file",
  _postfixComment: "at the bottom of the file"
}
```

We use underscores to remain forwards-compatible with the specification. It's possible `Prefix-Comment:` or `Postfix-Comment:` might be added as directives, however unlikely, and it would be horrible to deal with it.

<hr>

```
{
  contact: {
    comment: 'optional comment',
    value: 'Required value. Can be array of values.'
  }
}
```

<hr>

<code>
<pre>{
  contact: [
    {
      comment: 'optional comment',
      value: 'Required value. <s>Can be array of values</s> <em>Latest changes prevent nested arrays</em>'
    },
    'we can mix this with just values on their own'
  ]
}</pre>
</code>
<hr>

- There are no breaking changes. Existing notation still works
- Documentation is modified: an example email address gets a `mailto:` prefix per spec
- Documentation is modified: add examples of array chaining and all the different comment notations
- Tests are added: to cover the above changes regarding comments