### PR TITLE
(att. 2) Implement comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ const options = {
 
 app.use(securityTxt.setup(options))
 ```
-
 ### Chaining
 
 Where allowed, you can provide multiple values for a single directive by passing an array.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and use it as a middleware for an express app.
 const securityTxt = require('express-security-txt')
 
 const options = {
-  contact: 'email@example.com',
+  contact: 'mailto:email@example.com',
   encryption: 'https://www.mykey.com/pgp-key.txt',
   acknowledgement: 'thank you'
 }
@@ -42,6 +42,81 @@ const options = {
 app.use(securityTxt.setup(options))
 ```
 
+### Chaining
+
+Where allowed, you can provide multiple values for a single directive by passing an array.
+
+```js
+const securityTxt = require('express-security-txt')
+
+const options = {
+  contact: [
+    'https://firstMethodOfContact.example.com',
+    'https://secondMethodOfContact.example.com'
+  ]
+}
+
+app.use(securityTxt.setup(options))
+```
+
+### Comments
+
+To add a comment at the beggining or end of the security.txt file, one may use the keys `_prefixComment` and `postfixComment` respectively. If one wishes to place a comment immediately before a field, one may use an object which specifies the value of the field and the comment which must introduce it.
+
+```js
+const securityTxt = require('express-security-txt')
+
+const options = {
+  _prefixComment: 'This comment goes at the very beggining of the file',
+  contact: {
+    comment: 'This comment goes directly before the Contact: directive',
+    value: 'mailto:email@example.com'
+  },
+  encryption: [
+    'https://example.com/encryption',
+    {
+      comment: 'Comments can appear in the middle of an array of values',
+      value: 'https://example.com/alternativeEncryption'
+    }
+  ],
+  _postfixComment: 'This comment goes at the very end of the file'
+}
+
+app.use(securityTxt.setup(options))
+```
+
+Would generate the file
+
+```txt
+# This comment goes at the very beggining of the file
+# This comment goes directly before the Contact: directive
+Contact: mailto:email@example.com
+Encryption: https://example.com/encryption
+# Comments can appear in the middle of an array of values
+Encryption: https://example.com/alternativeEncryption
+# This comment goes at the very end of the file
+```
+
+If your comment spans multiple lines, you can use `\n` to split it. express-security-txt will automatically insert the relevant `#` symbols. Alternatively, one can use an array of lines instead of a string.
+
+For example:
+
+```js
+const options = {
+  _prefixComment: ['this is a', 'comment\nwhich', 'spans many lines'],
+  contact: 'mailto:email@example.com'
+}
+```
+
+Would generate
+
+```txt
+# this is a
+# comment
+# which
+# spans many lines
+Contact: mailto:email@example.com
+```
 ## Tests
 
 Project tests:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ app.use(securityTxt.setup(options))
 
 ### Comments
 
-To add a comment at the beggining or end of the security.txt file, one may use the keys `_prefixComment` and `postfixComment` respectively. If one wishes to place a comment immediately before a field, one may use an object which specifies the value of the field and the comment which must introduce it.
+To add a comment at the beggining or end of the security.txt file, one may use the keys `_prefixComment` and `_postfixComment` respectively. If one wishes to place a comment immediately before a field, one may use an object which specifies the value of the field and the comment which must come before it.
 
 ```js
 const securityTxt = require('express-security-txt')

--- a/__tests__/formatPolicy.test.js
+++ b/__tests__/formatPolicy.test.js
@@ -95,3 +95,37 @@ test('camelCasing works for different types of directives', () => {
   expect(securityTxt.camelCase('Abc-Def')).toBe('abcDef')
   expect(securityTxt.camelCase('Abc-Def-Ghi')).toBe('abcDefGhi')
 })
+
+test('formats successfully with comments', () => {
+  const options = {
+    contact: {
+      comment: 'b',
+      value: 'tel:+123'
+    },
+    encryption: [
+      {
+        value: 'https://a.example.com'
+      },
+      {
+        value: 'https://b.example.com',
+        comment: 'c'
+      },
+      'https://c.example.com'
+    ],
+    _prefixComment: 'a',
+    _postfixComment: 'd'
+  }
+
+  const res = securityTxt.formatSecurityPolicy(options)
+
+  expect(res).toBe(
+    '# a\n' +
+    '# b\n' +
+    'Contact: tel:+123\n' +
+    'Encryption: https://a.example.com\n' +
+    '# c\n' +
+    'Encryption: https://b.example.com\n' +
+    'Encryption: https://c.example.com\n' +
+    '# d\n'
+  )
+})

--- a/__tests__/formatPolicy.test.js
+++ b/__tests__/formatPolicy.test.js
@@ -108,11 +108,11 @@ test('formats successfully with comments', () => {
       },
       {
         value: 'https://b.example.com',
-        comment: 'c'
+        comment: ['c', 'h', 'i\nj']
       },
       'https://c.example.com'
     ],
-    _prefixComment: 'a',
+    _prefixComment: ['a', 'z', 'x\ny'],
     _postfixComment: 'd'
   }
 
@@ -120,10 +120,16 @@ test('formats successfully with comments', () => {
 
   expect(res).toBe(
     '# a\n' +
+    '# z\n' +
+    '# x\n' +
+    '# y\n' +
     '# b\n' +
     'Contact: tel:+123\n' +
     'Encryption: https://a.example.com\n' +
     '# c\n' +
+    '# h\n' +
+    '# i\n' +
+    '# j\n' +
     'Encryption: https://b.example.com\n' +
     'Encryption: https://c.example.com\n' +
     '# d\n'

--- a/__tests__/validatePolicy.test.js
+++ b/__tests__/validatePolicy.test.js
@@ -189,3 +189,12 @@ test('validate fails when not providing a value in comment object', () => {
   expect(() => securityTxt.validatePolicyFields(singleObject)).toThrow()
   expect(() => securityTxt.validatePolicyFields(arrayOfObjects)).toThrow()
 })
+
+test('validate fails when using a [{value: [...]}] nested array', () => {
+  const options = {
+    contact: [{ value: ['test'] }],
+    encryption: [{ value: ['test'] }]
+  }
+
+  expect(() => securityTxt.validatePolicyFields(options)).toThrow()
+})

--- a/__tests__/validatePolicy.test.js
+++ b/__tests__/validatePolicy.test.js
@@ -136,3 +136,56 @@ test('validate fails when providing arrays for signature/permission', () => {
 
   expect(() => securityTxt.validatePolicyFields(options)).toThrow()
 })
+
+test('validate successfully when using prefix/postfix comments', () => {
+  const options = {
+    _prefixComment: 'This is a prefix comment',
+    _postfixComment: 'This is a postfix comment',
+    contact: 'mailto:security@example.com'
+  }
+
+  expect(() => securityTxt.validatePolicyFields(options)).not.toThrow()
+})
+
+test('validate successfully when using objects for comments', () => {
+  const options = {
+    contact: [
+      {
+        comment: '...',
+        value: 'mailto:security@example.com'
+      },
+      {
+        value: 'tel:+123'
+      }
+    ],
+    encryption: {
+      comment: '...',
+      value: 'https://encryption.example.com'
+    }
+  }
+
+  expect(() => securityTxt.validatePolicyFields(options)).not.toThrow()
+})
+
+test('validate fails when not providing a value in comment object', () => {
+  const singleObject = {
+    contact: {
+      comment: ''
+    }
+  }
+
+  const arrayOfObjects = {
+    contact: [
+      {
+        comment: '...',
+        value: 'tel:+123'
+      },
+      {
+        comment: '...'
+      }
+    ]
+  }
+
+  expect(() => securityTxt.validatePolicyFields(singleObject)).toThrow()
+  expect(() => securityTxt.validatePolicyFields(arrayOfObjects)).toThrow()
+})

--- a/__tests__/validatePolicy.test.js
+++ b/__tests__/validatePolicy.test.js
@@ -139,8 +139,8 @@ test('validate fails when providing arrays for signature/permission', () => {
 
 test('validate successfully when using prefix/postfix comments', () => {
   const options = {
-    _prefixComment: 'This is a prefix comment',
-    _postfixComment: 'This is a postfix comment',
+    _prefixComment: ['This is a\nprefix', 'comment'],
+    _postfixComment: 'This is a \npostfix comment',
     contact: 'mailto:security@example.com'
   }
 
@@ -151,7 +151,7 @@ test('validate successfully when using objects for comments', () => {
   const options = {
     contact: [
       {
-        comment: '...',
+        comment: ['...', '...'],
         value: 'mailto:security@example.com'
       },
       {

--- a/index.js
+++ b/index.js
@@ -60,12 +60,20 @@ class middleware {
 
       let value = options[key] // eslint-disable-line security/detect-object-injection
 
-      if (typeof value !== 'object') {
+      if (!Array.isArray(value)) {
         value = [ value ]
       }
 
       value.forEach(valueOption => {
-        tmpPolicyArray.push(`${directive}: ${valueOption}\n`)
+        if (valueOption.hasOwnProperty('value')) {
+          if(valueOption.hasOwnProperty('comment')) {
+            tmpPolicyArray.push(asComment(valueOption.comment))
+          }
+
+          tmpPolicyArray.push(`${directive}: ${valueOption.value}\n`)
+        } else {
+          tmpPolicyArray.push(`${directive}: ${valueOption}\n`)
+        }
       })
     }
 

--- a/index.js
+++ b/index.js
@@ -34,6 +34,20 @@ class middleware {
     // Before applying formatting let's validate the options
     this.validatePolicyFields(options)
 
+    const asComment = comment => {
+      const flatten = (a, b) => a.concat(b)
+
+      if(!Array.isArray(comment)) {
+        comment = [ comment ]
+      }
+
+      return comment
+                    .map(n => n.split`\n`)
+                    .reduce(flatten, [])
+                    .map(n => `# ${n}\n`)
+                    .join``
+    }
+
     let policySettingText = ''
 
     const tmpPolicyArray = []
@@ -55,6 +69,14 @@ class middleware {
       })
     }
 
+    if(typeof options._prefixComment !== 'undefined') {
+      tmpPolicyArray.unshift(asComment(options._prefixComment))
+    }
+
+    if(typeof options._postfixComment !== 'undefined') {
+      tmpPolicyArray.push(asComment(options._postfixComment))
+    }
+
     policySettingText = tmpPolicyArray.join('')
     return policySettingText
   }
@@ -70,13 +92,15 @@ class middleware {
     const string = Joi.string()
 
     const schema = Joi.object().keys({
+      _prefixComment: string,
       acknowledgement: array.items(string),
       contact: array.required().items(string.required()),
       permission: string.only('none').insensitive(),
       encryption: array.items(string.regex(/^(?!http:)/i)),
       policy: array.items(string),
       hiring: array.items(string),
-      signature: string
+      signature: string,
+      _postfixComment: string
     }).label('options').required()
 
     const result = Joi.validate(options, schema)

--- a/index.js
+++ b/index.js
@@ -100,15 +100,15 @@ class middleware {
      * @param {object} [singleValue=Joi.string()] - a Joi schema to validate a single entry (e.g. of an array)
      * @param {boolean} [required=false] - whether this schema must be present
      */
-    const fieldValue = ({canBeArray = true, singleValue = string, required = false} = {}) => {
+    const fieldValue = ({ canBeArray = true, singleValue = string, required = false } = {}) => {
       let schema = Joi.alternatives()
-      
+
       schema = schema.try(singleValue)
       schema = schema.try(Joi.object().keys({
         comment: string,
         value: (canBeArray ? array.items(schema) : schema).required()
       }))
-      
+
       if (canBeArray) {
         schema = schema.try(array.items(schema))
       }
@@ -122,13 +122,13 @@ class middleware {
 
     const schema = Joi.object().keys({
       _prefixComment: string,
-      acknowledgement: fieldValue(), 
-      contact: fieldValue({required: true}),
-      permission: fieldValue({canBeArray: false, singleValue: string.only('none').insensitive()}),
-      encryption: fieldValue({singleValue: string.regex(/^(?!http:)/i)}),
+      acknowledgement: fieldValue(),
+      contact: fieldValue({ required: true }),
+      permission: fieldValue({ canBeArray: false, singleValue: string.only('none').insensitive() }),
+      encryption: fieldValue({ singleValue: string.regex(/^(?!http:)/i) }),
       policy: fieldValue(),
-      hiring: fieldValue(), 
-      signature: fieldValue({canBeArray: false}),
+      hiring: fieldValue(),
+      signature: fieldValue({ canBeArray: false }),
       _postfixComment: string
     }).label('options').required()
 

--- a/index.js
+++ b/index.js
@@ -66,14 +66,14 @@ class middleware {
 
       value.forEach(valueOption => {
         if (valueOption.hasOwnProperty('value')) {
-          if(valueOption.hasOwnProperty('comment')) {
+          if (valueOption.hasOwnProperty('comment')) {
             tmpPolicyArray.push(asComment(valueOption.comment))
           }
 
-          tmpPolicyArray.push(`${directive}: ${valueOption.value}\n`)
-        } else {
-          tmpPolicyArray.push(`${directive}: ${valueOption}\n`)
+          valueOption = valueOption.value
         }
+
+        tmpPolicyArray.push(`${directive}: ${valueOption}\n`)
       })
     }
 

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ class middleware {
 
       schema = schema.try(singleValue)
       schema = schema.try(Joi.object().keys({
-        comment: string,
+        comment: array.items(string),
         value: (canBeArray ? array.items(schema) : schema).required()
       }))
 
@@ -129,7 +129,7 @@ class middleware {
     }
 
     const schema = Joi.object().keys({
-      _prefixComment: string,
+      _prefixComment: array.items(string),
       acknowledgement: fieldValue(),
       contact: fieldValue({ required: true }),
       permission: fieldValue({ canBeArray: false, singleValue: string.only('none').insensitive() }),
@@ -137,7 +137,7 @@ class middleware {
       policy: fieldValue(),
       hiring: fieldValue(),
       signature: fieldValue({ canBeArray: false }),
-      _postfixComment: string
+      _postfixComment: array.items(string)
     }).label('options').required()
 
     const result = Joi.validate(options, schema)

--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ class middleware {
   static validatePolicyFields (options) {
     const array = Joi.array().single()
     const string = Joi.string()
+    const comment = array.items(string)
 
     /**
      * A function to create a custom schema for a security.txt
@@ -113,7 +114,7 @@ class middleware {
 
       schema = schema.try(singleValue)
       schema = schema.try(Joi.object().keys({
-        comment: array.items(string),
+        comment: comment,
         value: (canBeArray ? array.items(schema) : schema).required()
       }))
 
@@ -129,7 +130,7 @@ class middleware {
     }
 
     const schema = Joi.object().keys({
-      _prefixComment: array.items(string),
+      _prefixComment: comment,
       acknowledgement: fieldValue(),
       contact: fieldValue({ required: true }),
       permission: fieldValue({ canBeArray: false, singleValue: string.only('none').insensitive() }),
@@ -137,7 +138,7 @@ class middleware {
       policy: fieldValue(),
       hiring: fieldValue(),
       signature: fieldValue({ canBeArray: false }),
-      _postfixComment: array.items(string)
+      _postfixComment: comment
     }).label('options').required()
 
     const result = Joi.validate(options, schema)


### PR DESCRIPTION
Moved from #41 
Resolves #33 

I made a new branch, and then dropped and reordered the commits so that only the relevant ones should appear.

I compared this PR with the original PR -- only one change exists, which doesn't change the behaviour of the program, introduced during conflict resolution in the rebase.

I also fixed the nested array issue.

<hr>

We provide a few ways to add comments. I deviated a little from my interpretations of the restrictions you suggested, because I think it should be possible to add a comment without changing anything other than the affected area. Let me know if this is okay

<hr>

```
{
  _prefixComment: "at the top of the file",
  _postfixComment: "at the bottom of the file"
}
```

We use underscores to remain forwards-compatible with the specification. It's possible `Prefix-Comment:` or `Postfix-Comment:` might be added as directives, however unlikely, and it would be horrible to deal with it.

<hr>

```
{
  contact: {
    comment: 'optional comment',
    value: 'Required value. Can be array of values.'
  }
}
```

<hr>

```
{
  contact: [
    {
      comment: 'optional comment',
      value: 'Required value. CANNOT be an array of values'
    },
    'we can mix this with just values on their own'
  ]
}
```

<hr>

- There are no breaking changes. Existing notation still works (the last commit is marked a breaking change; it's just removing part of a feature *introduced in this PR*)
- Documentation is modified: an example email address gets a `mailto:` prefix per spec
- Documentation is modified: add examples of array chaining and all the different comment notations
- Tests are added: to cover the above changes regarding comments
