### PR TITLE
Create a way to easily deprecate fields; and insert 'Acknowledgement' into that list

### DIFF
--- a/__tests__/formatPolicy.test.js
+++ b/__tests__/formatPolicy.test.js
@@ -4,7 +4,7 @@ test('formats successfully with correct fields (singular contact field)', () => 
   const options = {
     contact: 'email@example.com',
     encryption: 'https://www.mykey.com/pgp-key.txt',
-    acknowledgement: 'thank you',
+    acknowledgments: 'thank you',
     permission: 'none'
   }
 
@@ -13,7 +13,7 @@ test('formats successfully with correct fields (singular contact field)', () => 
   expect(res).toBe(
     'Contact: email@example.com\n' +
     'Encryption: https://www.mykey.com/pgp-key.txt\n' +
-    'Acknowledgement: thank you\n' +
+    'Acknowledgments: thank you\n' +
     'Permission: none\n'
   )
 })
@@ -35,7 +35,7 @@ test('formats successfully with multiple contact options and values in-tact', ()
   const website = 'http://www.website.com'
   const phone = '+972+8+6173651'
   const encryption = 'https://www.mykey.com/pgp-key.txt'
-  const acknowledgement = 'http://my.website.com'
+  const acknowledgments = 'http://my.website.com'
 
   const options = {
     contact: [
@@ -43,8 +43,8 @@ test('formats successfully with multiple contact options and values in-tact', ()
       website,
       phone
     ],
-    encryption: encryption,
-    acknowledgement: acknowledgement
+    encryption,
+    acknowledgments
   }
 
   const res = securityTxt.formatSecurityPolicy(options)
@@ -54,7 +54,7 @@ test('formats successfully with multiple contact options and values in-tact', ()
     `Contact: ${website}\n` +
     `Contact: ${phone}\n` +
     `Encryption: ${encryption}\n` +
-    `Acknowledgement: ${acknowledgement}\n`
+    `Acknowledgments: ${acknowledgments}\n`
   )
 })
 
@@ -133,5 +133,19 @@ test('formats successfully with comments', () => {
     'Encryption: https://b.example.com\n' +
     'Encryption: https://c.example.com\n' +
     '# d\n'
+  )
+})
+
+test('uses new spelling with deprecated keys', () => {
+  const options = {
+    contact: 'tel:+123',
+    acknowledgement: 'https://example.com'
+  }
+
+  const res = securityTxt.formatSecurityPolicy(options)
+
+  expect(res).toBe(
+    'Contact: tel:+123\n' +
+    'Acknowledgments: https://example.com\n'
   )
 })

--- a/__tests__/middleware.test.js
+++ b/__tests__/middleware.test.js
@@ -4,7 +4,7 @@ test('correctly handle middleware setup for security policy', () => {
   const options = {
     contact: 'email@example.com',
     encryption: 'https://www.mykey.com/pgp-key.txt',
-    acknowledgement: 'thank you'
+    acknowledgments: 'thank you'
   }
 
   const middleware = securityTxtMiddleware.setup(options)
@@ -37,7 +37,7 @@ test('skip middleware if method is not GET', () => {
   const options = {
     contact: 'email@example.com',
     encryption: 'https://www.mykey.com/pgp-key.txt',
-    acknowledgement: 'thank you'
+    acknowledgments: 'thank you'
   }
 
   const middleware = securityTxtMiddleware.setup(options)
@@ -58,7 +58,7 @@ test('skip middleware if path is not /security.txt', () => {
   const options = {
     contact: 'email@example.com',
     encryption: 'https://www.mykey.com/pgp-key.txt',
-    acknowledgement: 'thank you'
+    acknowledgments: 'thank you'
   }
 
   const middleware = securityTxtMiddleware.setup(options)

--- a/__tests__/validatePolicy.test.js
+++ b/__tests__/validatePolicy.test.js
@@ -4,7 +4,7 @@ test('validate doesnt throw an error on provided fields', () => {
   const options = {
     contact: 'email@example.com',
     encryption: 'https://www.mykey.com/pgp-key.txt',
-    acknowledgement: 'thank you'
+    acknowledgments: 'thank you'
   }
 
   const res = securityTxt.validatePolicyFields(options)
@@ -60,11 +60,11 @@ test('validate fails when encryption property is not a string or array', () => {
   expect(() => securityTxt.validatePolicyFields(options)).toThrow()
 })
 
-test('validate fails when acknowledgement property is not a string or array', () => {
+test('validate fails when acknowledgments property is not a string or array', () => {
   const options = {
     contact: 'email@example.com',
     encryption: '',
-    acknowledgement: {}
+    acknowledgments: {}
   }
 
   expect(() => securityTxt.validatePolicyFields(options)).toThrow()
@@ -118,7 +118,7 @@ test('validate fails when permission property is not "none"', () => {
 test('validate successfully when providing arrays', () => {
   const options = {
     contact: ['a', 'b', 'c'],
-    acknowledgement: ['a', 'b', 'c'],
+    acknowledgments: ['a', 'b', 'c'],
     policy: ['a', 'b', 'c'],
     hiring: ['a', 'b', 'c'],
     encryption: ['a', 'b', 'c']
@@ -194,6 +194,25 @@ test('validate fails when using a [{value: [...]}] nested array', () => {
   const options = {
     contact: [{ value: ['test'] }],
     encryption: [{ value: ['test'] }]
+  }
+
+  expect(() => securityTxt.validatePolicyFields(options)).toThrow()
+})
+
+test('deprecated spelling is allowed', () => {
+  const options = {
+    contact: '...',
+    acknowledgement: '...' // deprecated spelling
+  }
+
+  expect(() => securityTxt.validatePolicyFields(options)).not.toThrow()
+})
+
+test('using both deprecated spelling and new spelling throws', () => {
+  const options = {
+    contact: '...',
+    acknowledgments: '...',
+    acknowledgement: '...'
   }
 
   expect(() => securityTxt.validatePolicyFields(options)).toThrow()

--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ class middleware {
      * @param {string} b - The correct spelling, which may or may not have a deprecated spelling
      * @return {array} An array with both the correct spellings and the deprecated spellings, with order conserved.
      */
+    // eslint-disable-next-line security/detect-object-injection
     const addDeprecatedSpellings = (a, b) => DEPRECATIONS.hasOwnProperty(b) ? a.concat(b, DEPRECATIONS[b]) : a.concat(b)
 
     /**
@@ -199,6 +200,7 @@ class middleware {
       const [camelDep, camelNotDep] = [deprecated, notDeprecated].map(this.camelCase)
 
       schema = schema.keys({
+        // eslint-disable-next-line security/detect-object-injection
         [camelDep]: uncompiledSchema[camelNotDep] // copy the schema for non-deprecated into deprecated
       })
 


### PR DESCRIPTION
Resolves #39 

We add an object to store our depredations.

https://github.com/lirantal/express-security-txt/blob/3e552979856da0836124263bf544ce5c1d73ed8c/index.js#L6-L17

- When two spellings of the same directive are encountered, validation fails
- When a deprecated spelling is encountered, the correct spelling is displayed in output
- When a deprecated spelling is encountered, we `console.warn` the user
- The object is easy to add to or remove from

On the other hand, is this amount of baggage needed if this is probably going to be the only time we need to deprecate something. The spec has nearly left draft and is in final call? Maybe we should just special case it? We should definitely remove it after the spec becomes stable.