### PR TITLE
test(formatPolicy.test.js): Mock console.warn in tests

### DIFF
--- a/__tests__/formatPolicy.test.js
+++ b/__tests__/formatPolicy.test.js
@@ -142,10 +142,14 @@ test('uses new spelling with deprecated keys', () => {
     acknowledgement: 'https://example.com'
   }
 
+  global.console.warn = jest.fn()
+
   const res = securityTxt.formatSecurityPolicy(options)
 
   expect(res).toBe(
     'Contact: tel:+123\n' +
     'Acknowledgments: https://example.com\n'
   )
+
+  expect(global.console.warn).toHaveBeenCalled()
 })


### PR DESCRIPTION
The test for deprecated keys would trigger a console.warning, per design, so that if a user was
using the deprecated spelling -- they would be told about it so that they could correct the issue.
However, the warning would be confusing during testing -- because the test was running correctly.
Hence, we mock console.warn so that the warning does not show up in the tests, and also ensures that
the warning is not accidentally removed.

Resolves #46