### PR TITLE
(att. 2) Add the 'Preferred-Languages' directive

### DIFF
--- a/__tests__/formatPolicy.test.js
+++ b/__tests__/formatPolicy.test.js
@@ -153,3 +153,31 @@ test('uses new spelling with deprecated keys', () => {
 
   expect(global.console.warn).toHaveBeenCalled()
 })
+
+test('preferredLanguages directive works with multiple values', () => {
+  const options = {
+    contact: 'mailto:security@example.com',
+    preferredLanguages: ['en', 'ru', 'es']
+  }
+
+  const res = securityTxt.formatSecurityPolicy(options)
+
+  expect(res).toBe(
+    'Contact: mailto:security@example.com\n' +
+    'Preferred-Languages: en, ru, es\n'
+  )
+})
+
+test('preferredLanguages directive works with one value only', () => {
+  const options = {
+    contact: 'mailto:security@example.com',
+    preferredLanguages: 'en'
+  }
+
+  const res = securityTxt.formatSecurityPolicy(options)
+
+  expect(res).toBe(
+    'Contact: mailto:security@example.com\n' +
+    'Preferred-Languages: en\n'
+  )
+})

--- a/__tests__/validatePolicy.test.js
+++ b/__tests__/validatePolicy.test.js
@@ -229,6 +229,23 @@ test('validate successfully for the preferredLanguages key', () => {
     preferredLanguages: 'ru'
   }
 
+  const optionsWithComment = {
+    contact: '...',
+    preferredLanguages: { comment: 'I am fluent in these', value: ['en', 'ru'] }
+  }
+
   expect(() => securityTxt.validatePolicyFields(optionsWithArray)).not.toThrow()
   expect(() => securityTxt.validatePolicyFields(optionsWithString)).not.toThrow()
+  expect(() => securityTxt.validatePolicyFields(optionsWithComment)).not.toThrow()
+})
+
+test('validate fails if Array<object> fed to preferredLanguages', () => {
+  const options = {
+    contact: '...',
+    preferredLanguages: [
+      { comment: '...', value: 'en' }
+    ]
+  }
+
+  expect(() => securityTxt.validatePolicyFields(options).toThrow())
 })

--- a/__tests__/validatePolicy.test.js
+++ b/__tests__/validatePolicy.test.js
@@ -217,3 +217,18 @@ test('using both deprecated spelling and new spelling throws', () => {
 
   expect(() => securityTxt.validatePolicyFields(options)).toThrow()
 })
+
+test('validate successfully for the preferredLanguages key', () => {
+  const optionsWithArray = {
+    contact: '...',
+    preferredLanguages: ['en', 'es']
+  }
+
+  const optionsWithString = {
+    contact: '...',
+    preferredLanguages: 'ru'
+  }
+
+  expect(() => securityTxt.validatePolicyFields(optionsWithArray)).not.toThrow()
+  expect(() => securityTxt.validatePolicyFields(optionsWithString)).not.toThrow()
+})

--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ class middleware {
       contact: fieldValue({ required: true }),
       permission: fieldValue({ canBeArray: false, singleValue: string.only('none').insensitive() }),
       encryption: fieldValue({ singleValue: string.regex(/^(?!http:)/i) }),
-      preferredLanguages: fieldValue(),
+      preferredLanguages: fieldValue({ canBeArray: false, singleValue: array.items(string)),
       policy: fieldValue(),
       hiring: fieldValue(),
       signature: fieldValue({ canBeArray: false }),

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const DIRECTIVES = ['Contact', 'Encryption', 'Acknowledgments', 'Signature', 'Policy', 'Hiring', 'Permission']
+const DIRECTIVES = ['Contact', 'Encryption', 'Acknowledgments', 'Preferred-Languages', 'Signature', 'Policy', 'Hiring', 'Permission']
 
 /**
  * @TODO Fully remove outdated spelling in breaking changes
@@ -104,6 +104,14 @@ class middleware {
         value = [ value ]
       }
 
+      // For the other fields, arrays are used to represent multiple occurences
+      // of a field. However, for the Preferred-Language: directive, an array shows
+      // a comma separated list. Convert the provided array into an array of one
+      // value: a string with commas.
+      if (outputDirective === 'Preferred-Languages') {
+        value = [ value.map(languageCode => languageCode.trim()).join(', ') ]
+      }
+
       value.forEach(valueOption => {
         if (valueOption.hasOwnProperty('value')) {
           if (valueOption.hasOwnProperty('comment')) {
@@ -187,6 +195,7 @@ class middleware {
       contact: fieldValue({ required: true }),
       permission: fieldValue({ canBeArray: false, singleValue: string.only('none').insensitive() }),
       encryption: fieldValue({ singleValue: string.regex(/^(?!http:)/i) }),
+      preferredLanguages: fieldValue(),
       policy: fieldValue(),
       hiring: fieldValue(),
       signature: fieldValue({ canBeArray: false }),

--- a/index.js
+++ b/index.js
@@ -195,7 +195,7 @@ class middleware {
       contact: fieldValue({ required: true }),
       permission: fieldValue({ canBeArray: false, singleValue: string.only('none').insensitive() }),
       encryption: fieldValue({ singleValue: string.regex(/^(?!http:)/i) }),
-      preferredLanguages: fieldValue({ canBeArray: false, singleValue: array.items(string)),
+      preferredLanguages: fieldValue({ canBeArray: false, singleValue: array.items(string) }),
       policy: fieldValue(),
       hiring: fieldValue(),
       signature: fieldValue({ canBeArray: false }),


### PR DESCRIPTION
Re-filed after #51 had some bugs

<hr>

This pull request adds the `Prefered-Languages:` directive. It can be used by providing a `preferredLanguages` key to an options object.

You can pass a string, an array of strings, or an object (for comments) with the `value` key of the object being one of those two.

If an array is provided, it will be joined by commas.

Automated tests are added to ensure all of the above works.