### PR TITLE
feat: Redirect from /security.txt to /.well-known/security.txt

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,12 +27,19 @@ class middleware {
     const securityPolicy = this.formatSecurityPolicy(options)
 
     return (req, res, next) => {
+      const CANONICAL = '/.well-known/security.txt'
+      const ALTERNATIVES = ['/security.txt']
+
       // Only handle requests for our intended use
-      if ((req.path === '/security.txt' || req.path === '/.well-known/security.txt') &&
-          req.method.toLowerCase() === 'get') {
-        return res.status(200).header('Content-Type', 'text/plain').send(securityPolicy)
+      if (req.method.toLowerCase() === 'get') {
+        if (ALTERNATIVES.includes(req.path)) {
+          return res.redirect(301, CANONICAL)
+        } else if (req.path === CANONICAL) {
+          return res.status(200).header('Content-Type', 'text/plain').send(securityPolicy)
+        }
       }
 
+      // Client did not request a security.txt policy
       return next()
     }
   }


### PR DESCRIPTION
(Contains breaking changes)

- Resolves #57 
- Redirect from `/security.txt` to `/.well-known/security.txt`
- Move `/security.txt` into an array (of one item) and `/.well-known/security.txt` into a constant because it is now referenced twice in the code
- Update tests to use Jest's mock functions more effectively (i.e., create lots of mock functions and tell them what their return values are; instead of manually conducting all the testing with nested objects and `if` statements)
- Test for the changes made in this commit

Question: I've set the redirect to be a 301, which is for permanent redirections. Do you think a 302 is more appropriate? 