### PR TITLE
fix: update README for package health score

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 [![Known Vulnerabilities](https://snyk.io/test/github/lirantal/express-security-txt/badge.svg)](https://snyk.io/test/github/lirantal/express-security-txt)
 [![Security Responsible Disclosure](https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg)](https://github.com/nodejs/security-wg/blob/master/processes/responsible_disclosure_template.md)
 
-[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat)](https://github.com/semantic-release/semantic-release)
-[![Greenkeeper badge](https://badges.greenkeeper.io/lirantal/express-security-txt.svg)](https://greenkeeper.io/)
-[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+[![express-security-txt](https://snyk.io/advisor/npm-package/express-security-txt/badge.svg)](https://snyk.io/advisor/npm-package/express-security-txt)
 
 # Express Security Txt
 


### PR DESCRIPTION
Update README to show package health score from the [Snyk Advisor page for express-security-txt](https://snyk.io/advisor/npm-package/express-security-txt)